### PR TITLE
Make hourly_to_annual.py executable

### DIFF
--- a/hourly_to_annual.py
+++ b/hourly_to_annual.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 def hourly(x):
     """enter hourly salary and return annual salary"""
     ann_salary = x * 40.0 * 52.0 #assumes 40 hours a week and 52 weeks in a year


### PR DESCRIPTION
With this change, on most terminals, it becomes possible to run
hourly_to_annual.py by executing it directly.  Where before one needed
to run something like:

$ python3 hourly_to_annual.py

now one can run

$ hourly_to_annual.py

There is discussion and explanation of the first line, known as the
shebang line, here:
https://stackoverflow.com/questions/6908143/should-i-put-shebang-in-python-scripts-and-what-form-should-it-take